### PR TITLE
Add "2017" to ReadMe as well as the existing "2015"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Command Task Runner extension
 
-Adds support for command line batch files in Visual Studio 2015's
+Adds support for command line batch files in Visual Studio 2015's & 2017's 
 Task Runner Explorer. Supports `.exe`, `.cmd`, `.bat`, `.ps1` and `.psm1` files.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/grreswaawyla0j6c?svg=true)](https://ci.appveyor.com/project/madskristensen/commandtaskrunner)


### PR DESCRIPTION
Current readme.md implies the extension is only for VS2015 as it says "Adds support for command line batch files in Visual Studio 2015's Task Runner Explorer" whereas the extension is also for VS2017.