### PR TITLE
Ignore vcxproj projects

### DIFF
--- a/src/TaskRunner/TaskRunnerProvider.cs
+++ b/src/TaskRunner/TaskRunnerProvider.cs
@@ -106,7 +106,7 @@ namespace CommandTaskRunner
             SolutionBuild build = sln.SolutionBuild;
             var slnCfg = (SolutionConfiguration2)build.ActiveConfiguration;
 
-            Project proj = projs.Cast<Project>().FirstOrDefault(x => x.FileName.Contains(cmdsDir));
+            Project proj = projs.Cast<Project>().FirstOrDefault(x => x.FileName.Contains(cmdsDir) && !x.FullName.EndsWith("vcxproj"));
 
             ApplyVariable("$(ConfigurationName)", slnCfg.Name, ref str);
             ApplyVariable("$(DevEnvDir)", Path.GetDirectoryName(dte.FileName), ref str);


### PR DESCRIPTION
They cause a null exception when accessing (string)projCfg.Properties.Item("OutputPath").Value;

fix #21 