### PR TITLE
Keep argument variables up to date

### DIFF
--- a/src/CommandTaskRunner.csproj
+++ b/src/CommandTaskRunner.csproj
@@ -56,6 +56,7 @@
     <Compile Include="source.extension.cs">
       <DependentUpon>source.extension.vsixmanifest</DependentUpon>
     </Compile>
+    <Compile Include="TaskRunner\DynamicTaskRunnerCommand.cs" />
     <Compile Include="VSCommandTable.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/TaskRunner/DynamicTaskRunnerCommand.cs
+++ b/src/TaskRunner/DynamicTaskRunnerCommand.cs
@@ -1,0 +1,51 @@
+﻿namespace CommandTaskRunner
+{
+    class DynamicTaskRunnerCommand : Microsoft.VisualStudio.TaskRunnerExplorer.ITaskRunnerCommand
+    {
+        public DynamicTaskRunnerCommand(TaskRunnerProvider provider, string rootDir, string workingDirectory, string exe, string args, string options = null)
+        {
+            this.provider = provider;
+            this.rootDir = rootDir;
+
+            Executable = exe;
+            Args = args;
+            WorkingDirectory = workingDirectory;
+            Options = options;
+        }
+
+        public string Executable
+        {
+            get {
+                return SetVariables(exe);
+            }
+            set {
+                exe = value;
+            }
+        }
+
+        public string Args
+        {
+            get {
+                return SetVariables(args);
+            }
+            set {
+                args = value;
+            }
+        }
+
+        public string WorkingDirectory { get; }
+        public string Options { get; set; }
+
+        private string SetVariables(string str)
+        {
+            return provider.SetVariables(str, rootDir);
+        }
+
+        private string args;
+        private string exe;
+
+        private TaskRunnerProvider provider;
+        private string rootDir;
+    }
+
+}

--- a/src/TaskRunner/TaskRunnerProvider.cs
+++ b/src/TaskRunner/TaskRunnerProvider.cs
@@ -94,7 +94,7 @@ namespace CommandTaskRunner
             str = str.Replace(key, value);
         }
 
-        private string SetVariables(string str, string cmdsDir)
+        public string SetVariables(string str, string cmdsDir)
         {
             if (str == null)
                 return str;
@@ -166,8 +166,6 @@ namespace CommandTaskRunner
 
             foreach (CommandTask command in commands.OrderBy(k => k.Name))
             {
-                command.Arguments = SetVariables(command.Arguments, rootDir);
-                command.FileName = SetVariables(command.FileName, rootDir);
                 command.Name = SetVariables(command.Name, rootDir);
                 command.WorkingDirectory = SetVariables(command.WorkingDirectory, rootDir);
 
@@ -177,9 +175,8 @@ namespace CommandTaskRunner
                 string commandName = command.Name += "\u200B";
                 SetDynamicTaskName(commandName);
 
-                var task = new TaskRunnerNode(commandName, true)
-                {
-                    Command = new TaskRunnerCommand(cwd, command.FileName, command.Arguments),
+                var task = new TaskRunnerNode(commandName, true) {
+                    Command = new DynamicTaskRunnerCommand(this, rootDir, cwd, command.FileName, command.Arguments),
                     Description = $"Filename:\t {command.FileName}\r\nArguments:\t {command.Arguments}"
                 };
 


### PR DESCRIPTION
Command argument variables like $(ConfigurationName) are now expanded to the current value for the time a command is executed. As requested in #4 and #33.