### PR TITLE
Remove zero space char from task names

### DIFF
--- a/src/Helpers/TaskRunner/BindingsPersister.cs
+++ b/src/Helpers/TaskRunner/BindingsPersister.cs
@@ -10,13 +10,9 @@ namespace ProjectTaskRunner.Helpers
 {
     internal class BindingsPersister
     {
-        private const string BindingsName = CommandTaskRunner.Constants.ELEMENT_NAME;
-        private TaskRunnerProvider _provider;
+        private const string BindingsName = Constants.ELEMENT_NAME;
 
-        public BindingsPersister(TaskRunnerProvider provider)
-        {
-            _provider = provider;
-        }
+        public BindingsPersister() { }
 
         public string Load(string configPath)
         {
@@ -45,11 +41,6 @@ namespace ProjectTaskRunner.Helpers
                 {
                     string[] tasks = property.Value.Values<string>().ToArray();
 
-                    for(int i = 0; i < tasks.Length; ++i)
-                    {
-                        tasks[i] = _provider.GetDynamicName(tasks[i]);
-                    }
-
                     bindingsElement.SetAttributeValue(property.Name, string.Join(",", tasks));
                 }
 
@@ -61,8 +52,6 @@ namespace ProjectTaskRunner.Helpers
 
         public bool Save(string configPath, string bindingsXml)
         {
-            bindingsXml = bindingsXml.Replace("\u200B", string.Empty);
-
             var bindingsXmlObject = XElement.Parse(bindingsXml);
             var bindingsXmlBody = JObject.Parse(@"{}");
             bool anyAdded = false;

--- a/src/Helpers/TaskRunner/TaskRunnerConfig.cs
+++ b/src/Helpers/TaskRunner/TaskRunnerConfig.cs
@@ -8,13 +8,8 @@ namespace ProjectTaskRunner.Helpers
     {
         private ImageSource _rootNodeIcon;
 
-        public TaskRunnerConfig(TaskRunnerProvider provider, ITaskRunnerCommandContext context, ITaskRunnerNode hierarchy)
-            : base(provider, context, hierarchy)
-        {
-        }
-
-        public TaskRunnerConfig(TaskRunnerProvider provider, ITaskRunnerCommandContext context, ITaskRunnerNode hierarchy, ImageSource rootNodeIcon)
-            : this(provider, context, hierarchy)
+        public TaskRunnerConfig(ITaskRunnerNode hierarchy, ImageSource rootNodeIcon)
+            : base(hierarchy)
         {
             _rootNodeIcon = rootNodeIcon;
         }

--- a/src/Helpers/TaskRunner/TaskRunnerConfigBase.cs
+++ b/src/Helpers/TaskRunner/TaskRunnerConfigBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Media;
-using CommandTaskRunner;
 using Microsoft.VisualStudio.TaskRunnerExplorer;
 
 namespace ProjectTaskRunner.Helpers
@@ -9,13 +8,11 @@ namespace ProjectTaskRunner.Helpers
     {
         private static ImageSource SharedIcon;
         private BindingsPersister _bindingsPersister;
-        private ITaskRunnerCommandContext _context;
 
-        protected TaskRunnerConfigBase(TaskRunnerProvider provider, ITaskRunnerCommandContext context, ITaskRunnerNode hierarchy)
+        protected TaskRunnerConfigBase(ITaskRunnerNode hierarchy)
         {
-            _bindingsPersister = new BindingsPersister(provider);
+            _bindingsPersister = new BindingsPersister();
             TaskHierarchy = hierarchy;
-            _context = context;
         }
 
         /// <summary>


### PR DESCRIPTION
Appending the zero space character was a trigger for refreshing
the task runner explorer that is no longer needed, and the zero space
character is causing problems with task bindings in VS2019. Removal
of this append to task name allows the bindings to correctly resolve.

Addresses VS2019 compatibility issue #34 