### PR TITLE
Add support for local user commands

### DIFF
--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -4,6 +4,7 @@ namespace CommandTaskRunner
     class Constants
     {
         public const string FILENAME = "commands.json";
+        public const string USERFILENAME = "commands.user.json";
         public const string ELEMENT_NAME = "-vs-binding";
         public const string TASK_CATEGORY = "Commands";
     }


### PR DESCRIPTION
**Summary:**
Adds support for user commands that are not shared with the team. User commands are specified in a "commands.user.json" file. Commands in this file are appended to a new command group. 

![image](https://user-images.githubusercontent.com/22841247/78466251-b9bc1480-76c4-11ea-8d1b-10c3023cc0cf.png)

The "Add to Task Runner" command continues to add to the global "commands.json".

**Use case:**
Developers in a team have local scripts they want to add to their task runner but do not want to clutter the teams task runner.

**Steps to use:**

1. Create local "commands.user.json" file with commands
2. Add "commands.user.json" to .gitignore



