### PR TITLE
Update Visual Studio version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Command Task Runner extension
 
-Adds support for command line batch files in Visual Studio 2015's & 2017's 
+Adds support for command line batch files in Visual Studio 2022's 
 Task Runner Explorer. Supports `.exe`, `.cmd`, `.bat`, `.ps1` and `.psm1` files.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/grreswaawyla0j6c?svg=true)](https://ci.appveyor.com/project/madskristensen/commandtaskrunner)


### PR DESCRIPTION
The [marketplace listing](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.CommandTaskRunner64) for the 2022-compatible extension still shows "Visual Studio 2015" in the description.

![yJO6qlLQnn](https://github.com/user-attachments/assets/6962f6f1-af83-4871-8492-6fc9d9a32bdd)


Strangely enough, the listing doesn't mention 2017 either, even though it was added to the README [7 years ago](https://github.com/madskristensen/CommandTaskRunner/commit/6f92856663bd2acc0bff030e866c1d57a23a5aa3). Is is possible that the 2022 listing was published with an older version of the codebase instead of what was latest at the time?